### PR TITLE
Update index.rst to add a vpnsop link from the https://oresat-vpn.readthedocs.io/en/latest/ index.rst page to the new VPN SOP page vpnsop.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,3 +10,4 @@ Read through the below documents:
    :maxdepth: 2
 
    glossary
+   vpnsop


### PR DESCRIPTION
Hi Dmitri, this change is to add a new link named 'vpnsop' on https://oresat-vpn.readthedocs.io/en/latest/ index.rst page to redirect the user to the new VPN SOP page vpnsop.rst in https://github.com/oresat/oresat-vpn/pull/1/commits/c20dad1265354e3e4a9b80c9e1bbfd3d6a617c55. I simply added the new name of the rst file 'vpnsop' similar to how the 'glossary' link is currently displaying on the index page.